### PR TITLE
Added support for multi-value eval output

### DIFF
--- a/src/deps.lisp
+++ b/src/deps.lisp
@@ -173,7 +173,9 @@
 (defun do-eval (data)
     (unless *deps* (error "Dependencies not set"))
 
-    (funcall (deps-eval-fn *deps*) data))
+    (let ((results (multiple-value-list (funcall (deps-eval-fn *deps*) data))))
+        (finish-output)
+        results))
 
 
 (declaim (ftype (function (string string) (values list &optional)) macro-expand))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -197,9 +197,9 @@
           (logger logger:*logger*))
         (bt:make-thread (lambda ()
                             (let ((*server* server)
-                                  (logger:*logger* logger))
-                                (let ((*standard-output* stdout))
-                                    (listen-for-conns port))))
+                                  (logger:*logger* logger)
+                                  (*standard-output* stdout))
+                                (listen-for-conns port)))
                         :name "Alive LSP Server")))
 
 

--- a/src/session/transport.lisp
+++ b/src/session/transport.lisp
@@ -21,8 +21,10 @@
     (state:lock (mutex)
         (when (and (hash-table-p msg)
                    (gethash "jsonrpc" msg))
-              (write-sequence (packet:to-wire msg) (context:get-output-stream))
-              (force-output (context:get-output-stream)))))
+
+              (let ((steam (context:get-output-stream)))
+                  (write-sequence (packet:to-wire msg) steam)
+                  (force-output steam)))))
 
 
 (declaim (ftype (function (hash-table) cons) send-request))


### PR DESCRIPTION
Now the `eval` call to LSP server is able to return both a string or an array of strings. Useful to correctly handle results from multiple values function call.

This is done sending an array of string trough json-rpc, in case multiple values are returned from `do-eval`.

Also small formatting changes.

Frontend PR: https://github.com/nobody-famous/alive/pull/206

```
[Trace - 20:30:59] Sending request '$/alive/eval - (295)'.
Params: {
    "text": "(floor 2 3)",
    "package": "cl-user",
    "storeResult": true
}
...
[Trace - 20:30:59] Received response '$/alive/eval - (295)' in 13ms.
Result: {
    "text": [
        "0",
        "2"
    ]
}
```