### PR TITLE
Use hash table instead of list for threads

### DIFF
--- a/src/session/handler/threads.lisp
+++ b/src/session/handler/threads.lisp
@@ -17,7 +17,7 @@
 (defun list-all (deps state msg)
     (state:lock (state mutex)
         (let ((threads (remove-if (lambda (thread)
-                                      (eq (cdr (assoc :id thread)) (deps:get-thread-id deps (bt:current-thread))))
+                                      (eq (gethash "id" thread) (deps:get-thread-id deps (bt:current-thread))))
                                (deps:list-all-threads deps))))
 
             (utils:result (cdr (assoc :id msg)) "threads" threads))))
@@ -31,8 +31,7 @@
                                                         :code errors:*request-cancelled*
                                                         :message (format nil "Request ~A canceled" msg-id))))
 
-        (when thread-id
-              (ignore-errors (deps:kill-thread deps thread-id)))))
+        (ignore-errors (deps:kill-thread deps thread-id))))
 
 
 (declaim (ftype (function (deps:dependencies state:state cons) (values hash-table &optional)) kill))

--- a/src/sys/threads.lisp
+++ b/src/sys/threads.lisp
@@ -12,12 +12,17 @@
     #+sbcl (alive/sbcl/threads:get-thread-id thread))
 
 
-(declaim (ftype (function () cons) list=all))
+(declaim (ftype (function (sb-thread:thread) hash-table) thread-to-wire))
+(defun thread-to-wire (thread)
+    (let ((table (make-hash-table :test #'equalp)))
+        (setf (gethash "id" table) (get-id thread))
+        (setf (gethash "name" table) (get-id thread))
+        table))
+
+
+(declaim (ftype (function () cons) list-all))
 (defun list-all ()
-    (mapcar (lambda (thread)
-                (list (cons :id (get-id thread))
-                      (cons :name (bt:thread-name thread))))
-            (bt:all-threads)))
+    (mapcar #'thread-to-wire (bt:all-threads)))
 
 
 (declaim (ftype (function (T) bt:thread) find-by-id))


### PR DESCRIPTION
Using a list of cons cells doesn't allow `null` as a value, so use a hash-table instead.