### PR TITLE
Translate logical pathnames in definition lookup

### DIFF
--- a/src/symbols.lisp
+++ b/src/symbols.lisp
@@ -143,7 +143,7 @@
     (let* ((src (when sym (lookup-sources sym)))
            (file (when src (sb-introspect:definition-source-pathname src))))
 
-        (when file (namestring file))))
+        (when file (namestring (translate-logical-pathname file)))))
 
 
 (defun get-location (sym)
@@ -152,7 +152,7 @@
            (form-path (when src (sb-introspect:definition-source-form-path src))))
 
         (if file
-            (list (utils:url-encode-filename (namestring file))
+            (list (utils:url-encode-filename (namestring (translate-logical-pathname file)))
                   (get-range-from-file file form-path))
             (list nil nil))))
 


### PR DESCRIPTION
I tried using jump to definition on built in functions like "format" etc... and that didnt work because get-location and get-source-file in src/symbols.lisp call namestring on the pathname returned by sb-introspect:definition-source-pathname, but SBCL returns logical pathnames for its own source files (e.g. SYS:SRC;CODE;CMACROS.LISP). These get passed as-is to the editor, which can't open them since they aren't real filesystem paths.

This change wraps the namestring calls with translate-logical-pathname so that logical pathnames are resolved to physical paths (e.g. /opt/homebrew/share/sbcl-source/src/code/cmacros.lisp) before being sent to the editor.
This fixes jump-to-definition for SBCL built-in symbols like format, mapcar, etc., when the SBCL source is installed and sb-ext:set-sbcl-source-location has been called.